### PR TITLE
group_special change

### DIFF
--- a/bgtools/dominion_dividers/views.py
+++ b/bgtools/dominion_dividers/views.py
@@ -405,6 +405,7 @@ def _init_options_from_form_data(post_data):
         options.order = data['order']
         options.group_special = data['group_special']
         options.language = data['language']
+        options.group_global = None  # Default to no global groupings of Events, Landmarks, Ways, etc
         options.exclude_events = data['events']
         options.exclude_landmarks = data['events']
         options.text_front = data['divider_front_text']

--- a/bgtools/dominion_dividers/views.py
+++ b/bgtools/dominion_dividers/views.py
@@ -403,7 +403,7 @@ def _init_options_from_form_data(post_data):
         options.cost = data['cost_icon']
         options.set_icon = data['set_icon']
         options.order = data['order']
-        options.special_card_groups = data['group_special']
+        options.group_special = data['group_special']
         options.language = data['language']
         options.exclude_events = data['events']
         options.exclude_landmarks = data['events']


### PR DESCRIPTION
I *think* this may fix the group_special issue https://github.com/sumpfork/dominiontabs/issues/320.
I don't have a way to test this out right now, but I think this may fix the problem since main.py code uses the ArgParser to alias special-card-groups to group_special.  In this case ArgParser is being bypassed, I think.  So the variable to set is group_special.